### PR TITLE
Add "Generate Unreal Visual Studio Project Files" toolbar button

### DIFF
--- a/FUnreal/FUnreal.csproj
+++ b/FUnreal/FUnreal.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Sources\Core\Files\FUnrealCSharpFile.cs" />
     <Compile Include="Sources\Core\Files\FUnrealTargetFile.cs" />
     <Compile Include="Sources\Core\Files\FUnrealBuildVersionFile.cs" />
+    <Compile Include="Sources\UI\Common\Commands\CommandVsSln.cs" />
     <Compile Include="Sources\UI\Features\DetectEmptyFolderHandler.cs" />
     <Compile Include="Sources\UI\Features\ProjectReloadHandler.cs" />
     <Compile Include="Sources\Service\FUnrealServiceResults.cs" />

--- a/FUnreal/FUnrealPackage.cs
+++ b/FUnreal/FUnrealPackage.cs
@@ -57,8 +57,10 @@ namespace FUnreal
                 unrealVS.AddProjectLoadedHandler(projectLoadHandler.ExecuteAsync);
                 unrealVS.AddProjectLoadedHandler(emptyFolderHandler.ExecuteAsync);
 
-                //Bind Cmd with VSCT file (To be done after ContexMenuManager)
-                await this.RegisterCommandsAsync();
+                CommandVsSln.Service = unrealService;
+
+				//Bind Cmd with VSCT file (To be done after ContexMenuManager)
+				await this.RegisterCommandsAsync();
 
                 unrealVS.Output.Info($"{XDialogLib.Title_FUnreal} setup completed.");
                 unrealVS.ShowStatusBarMessage($"{XDialogLib.Title_FUnreal} is ready ;-)");

--- a/FUnreal/FUnrealPackage.vsct
+++ b/FUnreal/FUnrealPackage.vsct
@@ -3,6 +3,7 @@
 
   <Extern href="stdidcmd.h"/>
   <Extern href="vsshlids.h"/>
+  <Extern href="KnownImageIds.vsct"/>
   
   <Commands package="guidFUnrealPackage">
 
@@ -13,7 +14,14 @@
           <ButtonText>FUnreal</ButtonText>
         </Strings>
       </Menu>
-      
+
+      <Menu guid="guidFUnrealPackage" id="Toolbar" type="Toolbar">
+        <CommandFlag>DefaultDocked</CommandFlag>
+        <Strings>
+          <ButtonText>FUnreal</ButtonText>
+          <CommandName>FUnreal</CommandName>
+        </Strings>
+      </Menu>
     </Menus>
 
     <Groups>
@@ -26,6 +34,10 @@
       
       <Group guid="guidFUnrealPackage" id="ToolboxMenuInner02Group" priority="0x0002">
         <Parent guid="guidFUnrealPackage" id="ToolboxMenu"/>
+      </Group>
+
+      <Group guid="guidFUnrealPackage" id="ToolbarGroup" priority="0x0000">
+        <Parent guid="guidFUnrealPackage" id="Toolbar" />
       </Group>
 
     </Groups>
@@ -77,6 +89,15 @@
         </Strings>
       </Button>
 
+      <Button guid="guidFUnrealPackage" id="CmdVsSln" priority="0x0100" type="Button">
+        <Parent guid= "guidFUnrealPackage" id="ToolbarGroup" />
+        <Icon guid="ImageCatalogGuid" id="Solution" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings>
+          <ButtonText>Generate Unreal Visual Studio Project Files</ButtonText>
+        </Strings>
+      </Button>
+        
     </Buttons>
   </Commands>
 
@@ -139,7 +160,11 @@
       <IDSymbol name="Cmd13"             value="0x0013" />
       <IDSymbol name="Cmd21"             value="0x0021" />
       <IDSymbol name="Cmd22"             value="0x0022" />
+      <IDSymbol name="CmdVsSln"          value="0x0031" />
 
+      <IDSymbol name="Toolbar"      value="0x1000" />
+      <IDSymbol name="ToolbarGroup" value="0x1050" />
+        
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/FUnreal/Sources/UI/Common/Commands/CommandVsSln.cs
+++ b/FUnreal/Sources/UI/Common/Commands/CommandVsSln.cs
@@ -1,0 +1,19 @@
+﻿using Community.VisualStudio.Toolkit;
+using EnvDTE;
+using FUnreal.Sources.Core;
+using Microsoft.VisualStudio.Shell;
+using System.Security.Permissions;
+using System.Threading.Tasks;
+
+namespace FUnreal
+{
+	[Command(VSCTSymbols.CmdVsSln)]
+	internal sealed class CommandVsSln : BaseCommand<CommandVsSln>
+	{
+		public static FUnrealService Service { get; set; }
+		protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+		{
+			await FUnrealServiceTasks.Project_RegenSolutionFilesAsync(Service.GetUProject(), Service.Engine.UnrealBuildTool, new FUnrealNotifier());
+		}
+	}
+}

--- a/FUnreal/Sources/UI/Common/Commands/VSCTSymbols.cs
+++ b/FUnreal/Sources/UI/Common/Commands/VSCTSymbols.cs
@@ -9,5 +9,7 @@
         public const int Cmd13 = 0x0013;
         public const int Cmd21 = 0x0021;
         public const int Cmd22 = 0x0022;
+        
+        public const int CmdVsSln = 0x0031;
     }
 }


### PR DESCRIPTION
It's necessary to re-generate Visual Studio project files time to time when files changes outside visual studio. One frequent use case is needing to do this after pulling latest changes from Git. I usually navigate to the folder in the file explorer and use the context menu there. This is much more cumbersome than having the same ability inside Visual Studio.

Since FUnreal already got the ability to generate these, I believe providing a toolbar button to do that is a useful thing.

![image](https://github.com/fdefelici/vs-funreal/assets/27882764/942dd18b-4f0c-40b0-9ae0-e1f127cc45cf)
![image](https://github.com/fdefelici/vs-funreal/assets/27882764/c2dc58f4-5fe6-4683-b4fb-ed6d3663b9a0)

